### PR TITLE
Sig build rocm

### DIFF
--- a/tf_sig_build_dockerfiles/Dockerfile
+++ b/tf_sig_build_dockerfiles/Dockerfile
@@ -12,7 +12,7 @@ RUN /setup.packages.sh /builder.packages.txt
 COPY builder.devtoolset/fixlinks.sh /fixlinks.sh
 COPY builder.devtoolset/rpm-patch.sh /rpm-patch.sh
 COPY builder.devtoolset/build_devtoolset.sh /build_devtoolset.sh
-RUN /build_devtoolset.sh devtoolset-7 /dt7 
+RUN /build_devtoolset.sh devtoolset-8 /dt8 
 
 # Install devtoolset-9 in /dt9 with glibc 2.17 and libstdc++ 4.8, for building
 # manylinux2014-compatible packages.

--- a/tf_sig_build_dockerfiles/Dockerfile
+++ b/tf_sig_build_dockerfiles/Dockerfile
@@ -19,19 +19,20 @@ RUN /build_devtoolset.sh devtoolset-7 /dt7
 RUN /build_devtoolset.sh devtoolset-9 /dt9 
 
 ################################################################################
-FROM nvidia/cuda:11.2.2-base-ubuntu20.04 as devel
+FROM rocm/tensorflow-autobuilds:ubuntu20.04-rocm4.5.2 as devel
 ################################################################################
-
 COPY --from=builder /dt7 /dt7
 COPY --from=builder /dt9 /dt9
 
-# Install required development packages but delete unneeded CUDA bloat
-# CUDA must be cleaned up in the same command to prevent Docker layer bloating
+# Install required development packages
+# Install ROCm by version, i.e. 4.5.2
+ARG ROCM_VERS
 COPY setup.sources.sh /setup.sources.sh
 COPY setup.packages.sh /setup.packages.sh
-COPY setup.cuda.sh /setup.cuda.sh
+COPY setup.rocm.sh /setup.rocm.sh
 COPY devel.packages.txt /devel.packages.txt
-RUN /setup.sources.sh && /setup.packages.sh /devel.packages.txt && /setup.cuda.sh
+RUN /setup.sources.sh && /setup.packages.sh /devel.packages.txt
+# && /setup.rocm.sh $ROCM_VERS 
 
 # Install various tools.
 # - bats: bash unit testing framework
@@ -56,7 +57,7 @@ RUN echo $CACHEBUSTER
 ARG PYTHON_VERSION
 COPY setup.python.sh /setup.python.sh
 COPY devel.requirements.txt /devel.requirements.txt
-RUN /setup.python.sh $PYTHON_VERSION devel.requirements.txt
+RUN /setup.python.sh $PYTHON_VERSION /devel.requirements.txt
 
 # Setup build and environment
 COPY devel.usertools /usertools

--- a/tf_sig_build_dockerfiles/Dockerfile
+++ b/tf_sig_build_dockerfiles/Dockerfile
@@ -17,9 +17,8 @@ RUN /build_devtoolset.sh devtoolset-7 /dt7
 # Install devtoolset-9 in /dt9 with glibc 2.17 and libstdc++ 4.8, for building
 # manylinux2014-compatible packages.
 RUN /build_devtoolset.sh devtoolset-9 /dt9 
-
 ################################################################################
-FROM rocm/tensorflow-autobuilds:ubuntu20.04-rocm4.5.2 as devel
+#FROM rocm/tensorflow-autobuilds:ubuntu20.04-rocm4.5.2 as devel
 ################################################################################
 COPY --from=builder /dt7 /dt7
 COPY --from=builder /dt9 /dt9
@@ -31,8 +30,7 @@ COPY setup.sources.sh /setup.sources.sh
 COPY setup.packages.sh /setup.packages.sh
 COPY setup.rocm.sh /setup.rocm.sh
 COPY devel.packages.txt /devel.packages.txt
-RUN /setup.sources.sh && /setup.packages.sh /devel.packages.txt
-# && /setup.rocm.sh $ROCM_VERS 
+RUN /setup.sources.sh && /setup.packages.sh /devel.packages.txt && /setup.rocm.sh $ROCM_VERS 
 
 # Install various tools.
 # - bats: bash unit testing framework

--- a/tf_sig_build_dockerfiles/devel.packages.txt
+++ b/tf_sig_build_dockerfiles/devel.packages.txt
@@ -1,24 +1,3 @@
-# All required CUDA packages
-cuda-command-line-tools-11-2
-cuda-cudart-dev-11-2
-cuda-cupti-11-2
-cuda-nvprune-11-2
-cuda-libraries-11-2
-cuda-libraries-dev-11-2
-libcufft-11-2
-libcurand-11-2
-libcusolver-dev-11-2
-libcusparse-dev-11-2
-libcublas-dev-11-2
-# CuDNN: https://docs.nvidia.com/deeplearning/sdk/cudnn-install/index.html#ubuntu-network-installation
-libcudnn8-dev=8.1.0.77-1+cuda11.2
-libcudnn8=8.1.0.77-1+cuda11.2
-# TensorRT: See https://docs.nvidia.com/deeplearning/sdk/tensorrt-install-guide/index.html#maclearn-net-repo-install-rpm
-libnvinfer-plugin7=7.2.2-1+cuda11.1
-libnvinfer7=7.2.2-1+cuda11.1
-libnvinfer-dev=7.2.2-1+cuda11.1
-libnvinfer-plugin-dev=7.2.2-1+cuda11.1 
-
 # Other build-related tools
 apt-transport-https
 autoconf
@@ -26,7 +5,7 @@ automake
 build-essential
 ca-certificates
 clang-8
-clang-format-12
+clang-format-9
 colordiff
 curl
 ffmpeg

--- a/tf_sig_build_dockerfiles/devel.requirements.txt
+++ b/tf_sig_build_dockerfiles/devel.requirements.txt
@@ -42,7 +42,8 @@ jax ~= 0.2.26
 jaxlib ~= 0.1.75
 
 # Needs to be addressed. Unblocked 2.4 branchcut cl/338377048
-PyYAML ~= 5.4.1
+# Added in ROCm docker via distutils
+# PyYAML ~= 5.4.1
 
 # For uploading
 auditwheel ~= 5.0.0

--- a/tf_sig_build_dockerfiles/devel.usertools/configure.rocm.sh
+++ b/tf_sig_build_dockerfiles/devel.usertools/configure.rocm.sh
@@ -1,0 +1,1 @@
+yes "" | ROCM_PATH=/opt/rocm TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python3 /tf/tensorflow/configure

--- a/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc
+++ b/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc
@@ -41,9 +41,11 @@ build --config=opt --config=rocm
 build --repo_env TF_NEED_ROCM=1
 build --action_env=ROCM_PATH="/opt/rocm/"
 build --action_env=GCC_HOST_COMPILER_PATH="/dt7/usr/bin/gcc"
+build --action_env=TF_SYSROOT="/dt7/usr/include"
+build --action_env=GCC_HOST_COMPILER_PREFIX="/usr/bin"
 build --action_env=ROCBLAS_TENSILE_LIBPATH="/opt/rocm/lib/library"
 build --action_env=LD_LIBRARY_PATH="/opt/rocm:/opt/rocm/lib:/dt7/lib:/dt7/lib64"
-build --crosstool_top=@sigbuild-r2.9_config_rocm//crosstool:toolchain
+build --crosstool_top=@ubuntu18.04-gcc7_manylinux2010-rocm//crosstool:toolchain
 
 
 # Test-related settings below this point.

--- a/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc
+++ b/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc
@@ -1,0 +1,93 @@
+# This bazelrc can build a GPU-supporting TF package.
+
+# Convenient cache configurations
+# Use a cache directory mounted to /tf/cache. Very useful!
+build:sigbuild_local_cache --disk_cache=/tf/cache
+# Use the public-access TF DevInfra cache (read only)
+build:sigbuild_remote_cache --remote_cache="https://storage.googleapis.com/tensorflow-devinfra-bazel-cache" --remote_upload_local_results=false
+# Write to the TF DevInfra cache (only works for internal TF CI)
+build:sigbuild_remote_cache_push --remote_cache="https://storage.googleapis.com/tensorflow-devinfra-bazel-cache" --google_default_credentials
+# Change the value of CACHEBUSTER when upgrading the toolchain, or when testing
+# different compilation methods. E.g. for a PR to test a new CUDA version, set
+# the CACHEBUSTER to the PR number.
+build --action_env=CACHEBUSTER=r2.9
+
+# Use Python 3.X as installed in container image
+build --action_env PYTHON_BIN_PATH="/usr/bin/python3"
+build --action_env PYTHON_LIB_PATH="/usr/lib/tf_python"
+build --python_path="/usr/bin/python3"
+
+# Build TensorFlow v2
+build --define=tf_api_version=2 --action_env=TF2_BEHAVIOR=1
+
+# Prevent double-compilation of some TF code, ref. b/183279666 (internal)
+# > TF's gen_api_init_files has a genrule to run the core TensorFlow code
+# > on the host machine. If we don't have --distinct_host_configuration=false,
+# > the core TensorFlow code will be built once for the host and once for the
+# > target platform.
+# See also https://docs.bazel.build/versions/master/guide.html#build-configurations-and-cross-compilation
+build --distinct_host_configuration=false
+
+# Target the AVX instruction set
+build --copt=-mavx --host_copt=-mavx
+
+# Store performance profiling log in the mounted artifact directory.
+# The profile can be viewed by visiting chrome://tracing in a Chrome browser.
+# See https://docs.bazel.build/versions/main/skylark/performance.html#performance-profiling
+build --profile=/tf/pkg/profile.json
+
+# ROCm: Set up compilation ROCm version and paths
+build --config=opt --config=rocm
+build --repo_env TF_NEED_ROCM=1
+build --action_env=ROCM_PATH="/opt/rocm-4.5.2/"
+build --action_env=GCC_HOST_COMPILER_PATH="/dt7/usr/bin/gcc"
+build --action_env=ROCBLAS_TENSILE_LIBPATH="/opt/rocm/lib/library"
+build --action_env=LD_LIBRARY_PATH="/opt/rocm-4.5.2:/opt/rocm-4.5.2/lib:/dt7/lib:/dt7/lib64"
+build --crosstool_top=@sigbuild-r2.9_config_rocm//crosstool:toolchain
+
+
+# Test-related settings below this point.
+test --build_tests_only --keep_going --test_output=errors --verbose_failures=true
+test --test_env=LD_LIBRARY_PATH
+# Local test jobs has to be 4 because parallel_gpu_execute is fragile, I think
+test --test_timeout=300,450,1200,3600 --local_test_jobs=4 --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute
+# Give only the list of failed tests at the end of the log
+test --test_summary=terse
+
+# "nonpip" tests are regular py_test tests.
+# Pass --config=nonpip to run the same suite of tests. If you want to run just
+# one test for investigation, you don't need --config=nonpip; just run the
+# bazel test invocation as normal.
+test:nonpip --test_tag_filters=gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_cuda11
+test:nonpip --build_tag_filters=gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_cuda11
+test:nonpip --test_lang_filters=py --flaky_test_attempts=3 --test_size_filters=small,medium
+test:nonpip -- //tensorflow/... -//tensorflow/python/integration_testing/... -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/compiler/xrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/...
+
+# "pip tests" run a similar suite of tests the "nonpip" tests, but do something
+# odd to attempt to validate the quality of the pip package. The wheel is
+# installed into a virtual environment, and then that venv is used to run all
+# bazel tests with a special flag "--define=no_tensorflow_py_deps=true", which
+# drops all the bazel dependencies for each py_test; this makes all the tests
+# use the wheel's TensorFlow installation instead of the one made available
+# through bazel. This must be done in a different root directory, //bazel_pip/...,
+# because "import tensorflow" run from the root directory would instead import
+# the folder instead of the venv package.
+# 
+# Pass --config=pip to run the same suite of tests. If you want to run just one
+# test for investigation, you'll need --config=pip_venv instead, and then you
+# can specify whichever target you want.
+test:pip_venv --action_env PYTHON_BIN_PATH="/bazel_pip/bin/python3"
+test:pip_venv --action_env PYTHON_LIB_PATH="/bazel_pip/lib/python3/site-packages"
+test:pip_venv --python_path="/bazel_pip/bin/python3"
+test:pip_venv --define=no_tensorflow_py_deps=true
+test:pip --config=pip_venv
+# Yes, we don't exclude the gpu tests on pip for some reason.
+test:pip --test_tag_filters=gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_cuda11,-no_pip,-nopip
+test:pip --build_tag_filters=gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_cuda11,-no_pip,-nopip
+test:pip --test_lang_filters=py --flaky_test_attempts=3 --test_size_filters=small,medium
+test:pip -- //bazel_pip/tensorflow/... -//bazel_pip/tensorflow/python/integration_testing/... -//bazel_pip/tensorflow/compiler/tf2tensorrt/... -//bazel_pip/tensorflow/compiler/xrt/... -//bazel_pip/tensorflow/core/tpu/... -//bazel_pip/tensorflow/lite/...
+
+# For building libtensorflow archives
+test:libtensorflow_test -- //tensorflow/tools/lib_package:libtensorflow_test //tensorflow/tools/lib_package:libtensorflow_java_test
+build:libtensorflow_build -- //tensorflow/tools/lib_package:libtensorflow.tar.gz //tensorflow/tools/lib_package:libtensorflow_jni.tar.gz //tensorflow/java:libtensorflow.jar //tensorflow/java:libtensorflow-src.jar //tensorflow/tools/lib_package:libtensorflow_proto.zip
+

--- a/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc
+++ b/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc
@@ -39,10 +39,10 @@ build --profile=/tf/pkg/profile.json
 # ROCm: Set up compilation ROCm version and paths
 build --config=opt --config=rocm
 build --repo_env TF_NEED_ROCM=1
-build --action_env=ROCM_PATH="/opt/rocm-4.5.2/"
+build --action_env=ROCM_PATH="/opt/rocm/"
 build --action_env=GCC_HOST_COMPILER_PATH="/dt7/usr/bin/gcc"
 build --action_env=ROCBLAS_TENSILE_LIBPATH="/opt/rocm/lib/library"
-build --action_env=LD_LIBRARY_PATH="/opt/rocm-4.5.2:/opt/rocm-4.5.2/lib:/dt7/lib:/dt7/lib64"
+build --action_env=LD_LIBRARY_PATH="/opt/rocm:/opt/rocm/lib:/dt7/lib:/dt7/lib64"
 build --crosstool_top=@sigbuild-r2.9_config_rocm//crosstool:toolchain
 
 

--- a/tf_sig_build_dockerfiles/setup.rocm.sh
+++ b/tf_sig_build_dockerfiles/setup.rocm.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Install ROCm libs
+ROCM_VERS=$1
+ROCM_PATH=/opt/rocm
+ROCM_REPO_URL=http://repo.radeon.com/rocm/apt/$ROCM_VERS/
+BUILD_JOB_ID=ubuntu
+LKG_BUILD_NUM=main
+echo deb [arch=amd64 trusted=yes] $ROCM_REPO_URL $BUILD_JOB_ID $LKG_BUILD_NUM > /etc/apt/sources.list.d/rocm.list
+apt-get update
+apt-get install -y kmod
+DEBIAN_FRONTEND=noninteractive apt-get install -y rocm-dev rocm-libs
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+echo -e "gfx900\ngfx906\ngfx908\ngfx90a\ngfx1030" >> $ROCM_PATH/bin/target.lst

--- a/tf_sig_build_dockerfiles/setup.sources.sh
+++ b/tf_sig_build_dockerfiles/setup.sources.sh
@@ -17,9 +17,6 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F5
 
 # Set up custom sources
 cat >/etc/apt/sources.list.d/custom.list <<SOURCES
-# Nvidia CUDA packages: 18.04 has more available than 20.04, and we use those
-deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /
-
 # More Python versions: Deadsnakes
 deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main
 deb-src http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main


### PR DESCRIPTION
Changes to turn CUDA->ROCm. 

Note I was using a 20.04 docker container that I built locally: rocm/tensorflow-autobuilds:ubuntu20.04-rocm4.5.2

We will need to update https://hub.docker.com/r/rocm/dev-ubuntu-20.04 with the changes made in https://github.com/ROCmSoftwarePlatform/frameworks-internal/pull/943. 

